### PR TITLE
Update CM_dependencies.cmake

### DIFF
--- a/CM_dependencies.cmake
+++ b/CM_dependencies.cmake
@@ -52,41 +52,37 @@ ENDIF ()
 # == cuDNN ==
 # ===========
 IF (DARKNET_USE_CUDA)
-	IF (WIN32)
-		# If installed according to the NVIDIA instructions, CUDNN should look like this:
-		#		C:\Program Files\NVIDIA\CUDNN\v8.x\...
-		# The .dll is named:
-		#		C:\Program Files\NVIDIA\CUDNN\v8.x\bin\cudnn64_8.dll
-		# And the header should look like:
-		#		C:\Program Files\NVIDIA\CUDNN\v8.x\include\cudnn.h
-		#
-		SET (CUDNN_DIR "C:/Program Files/NVIDIA/CUDNN/v8.x")
-		SET (CUDNN_DLL "${CUDNN_DIR}/bin/cudnn64_8.dll")
-		SET (CUDNN_LIB "${CUDNN_DIR}/lib/x64/cudnn.lib")
-		SET (CUDNN_HEADER "${CUDNN_DIR}/include/cudnn.h")
-		IF (EXISTS ${CUDNN_DLL} AND EXISTS ${CUDNN_LIB} AND EXISTS ${CUDNN_HEADER})
-			MESSAGE (STATUS "cuDNN found at ${CUDNN_DIR}")
-			INCLUDE_DIRECTORIES (${CUDNN_DIR}/include/)
-			ADD_COMPILE_DEFINITIONS (ABC_123_TESTING)
-			ADD_COMPILE_DEFINITIONS (CUDNN) # TODO this needs to be renamed
-			ADD_COMPILE_DEFINITIONS (CUDNN_HALF)
-			SET (DARKNET_LINK_LIBS ${DARKNET_LINK_LIBS} ${CUDNN_LIB})
-		ELSE ()
-			MESSAGE (WARNING "Did not find cuDNN at ${CUDNN_DIR}")
-		ENDIF ()
-	ELSE ()
-		# Should be slightly easier to deal with on Linux if it was installed correctly.
-		FIND_LIBRARY (CUDNN cudnn OPTIONAL QUIET)
-		IF (NOT CUDNN)
-			MESSAGE (STATUS "Skipping cuDNN")
-		ELSE ()
-			MESSAGE (STATUS "Enabling cuDNN")
-			ADD_COMPILE_DEFINITIONS (CUDNN) # TODO this needs to be renamed
-			ADD_COMPILE_DEFINITIONS (CUDNN_HALF)
-			SET (DARKNET_LINK_LIBS ${DARKNET_LINK_LIBS} ${CUDNN})
-		ENDIF ()
-	ENDIF ()
-ENDIF ()
+    IF (WIN32)
+        # Automatically detect cuDNN for Windows
+        FIND_PATH(CUDNN_INCLUDE cudnn.h HINTS ${CUDAToolkit_INCLUDE_DIRS} PATH_SUFFIXES cuda include)
+        FIND_LIBRARY(CUDNN_LIBRARY NAMES cudnn64_8 cudnn HINTS ${CUDAToolkit_LIBRARY_DIR} PATH_SUFFIXES bin lib/x64)
+
+        IF (CUDNN_INCLUDE AND CUDNN_LIBRARY)
+            MESSAGE(STATUS "cuDNN found.")
+            INCLUDE_DIRECTORIES(${CUDNN_INCLUDE})
+            ADD_COMPILE_DEFINITIONS(CUDNN) # TODO: Rename this to DARKNET_USE_CUDNN
+            ADD_COMPILE_DEFINITIONS(CUDNN_HALF)
+            SET(DARKNET_LINK_LIBS ${DARKNET_LINK_LIBS} ${CUDNN_LIBRARY})
+        ELSE()
+            MESSAGE(WARNING "cuDNN not found.")
+        ENDIF()
+    ELSE()
+        # Automatically detect cuDNN for Linux
+        FIND_PATH(CUDNN_INCLUDE cudnn.h HINTS ${CUDAToolkit_INCLUDE_DIRS} PATH_SUFFIXES cuda include)
+        FIND_LIBRARY(CUDNN_LIBRARY NAMES cudnn HINTS ${CUDAToolkit_LIBRARY_DIR} PATH_SUFFIXES lib lib64)
+
+        IF (CUDNN_INCLUDE AND CUDNN_LIBRARY)
+            MESSAGE(STATUS "cuDNN found.")
+            INCLUDE_DIRECTORIES(${CUDNN_INCLUDE})
+            ADD_COMPILE_DEFINITIONS(CUDNN) # TODO: Rename this to DARKNET_USE_CUDNN
+            ADD_COMPILE_DEFINITIONS(CUDNN_HALF)
+            SET(DARKNET_LINK_LIBS ${DARKNET_LINK_LIBS} ${CUDNN_LIBRARY})
+        ELSE()
+            MESSAGE(STATUS "Skipping cuDNN")
+        ENDIF()
+    ENDIF()
+ENDIF()
+
 
 
 # ========================


### PR DESCRIPTION
Here's what I've done.

First, I removed the hardcoded paths for cuDNN. We all know how annoying it is to dig through NVIDIA's folders to find the right files. Instead, I leveraged CMake's FIND_PATH and FIND_LIBRARY functions. These  commands automatically locate the cuDNN headers and libraries, assuming you've got CUDA installed properly and your system variables are set (which they should be if you've installed CUDA via the recommended methods).

For Windows, this was pretty straightforward. The CMake script now looks for cudnn.h and cudnn64_8.dll (or just cudnn if you've got a different version) in the places where CUDA usually resides. No more manual setting of the CUDNN_DIR variable—just let CMake handle it.

Here's the tricky part: I wasn't entirely sure how this would play out on Ubuntu, but the idea remains the same. CMake should look in the usual Linux library locations for cudnn.h and the libcudnn library. I'm counting on the FIND_PATH and FIND_LIBRARY commands to be just as effective on Ubuntu as they are on Windows. This part might need a bit of extra testing.

Lastly, I made sure to keep the naming consistent. Whether the script finds cuDNN on Windows or Ubuntu, it'll spit out  "cuDNN found." message. And if it doesn't, it'll let you know.