### PR TITLE
Fix crash on map 1000

### DIFF
--- a/src-lib/convolutional_layer.cpp
+++ b/src-lib/convolutional_layer.cpp
@@ -325,6 +325,7 @@ void cudnn_convolutional_setup(layer *l, int cudnn_preference, size_t workspace_
 	for (int i = 0; i < returned_algo_count; i++)
 	{
 		if (conv_fwd_results[i].status == CUDNN_STATUS_SUCCESS &&
+			conv_fwd_results[i].algo != CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM &&
 			conv_fwd_results[i].algo != CUDNN_CONVOLUTION_FWD_ALGO_WINOGRAD_NONFUSED &&
 			conv_fwd_results[i].memory < free_memory &&
 			(conv_fwd_results[i].memory <= workspace_size_specify || cudnn_preference == cudnn_fastest) &&


### PR DESCRIPTION
This fixes the known bug 

https://github.com/hank-ai/darknet/issues/1
https://github.com/AlexeyAB/darknet/issues/8669
https://github.com/AlexeyAB/darknet/issues/8766


I could reproduce it with current master on first try
<img width="622" alt="Screenshot 2024-01-08 124611" src="https://github.com/hank-ai/darknet/assets/77390911/66a63abc-c203-4889-8284-9f3597e67537">


This fix is not perfect since we loose some performance by not using CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM. However in our tests the difference during training was very low. (And if the last ms matters in production intereference on gpu ppl would use fp16 optimized freamworks like opencv anyway) 

The mid/long term fix will be to improve the cudnn <-> darknet interface but the current status is filled with so many warnings that it seems wasted to search for this one line when there are probably many bugs in this part of the code. 


Tested with current cuda and cudnn version. 
