### PR TITLE
Improve CMAKE Cudnn Handling

### DIFF
--- a/CM_dependencies.cmake
+++ b/CM_dependencies.cmake
@@ -54,25 +54,26 @@ ENDIF ()
 IF (DARKNET_USE_CUDA)
        	# Look for cudnn, we will look in the same place as other CUDA
 		# libraries and also a few other places as well.
-		find_path(cudnn_include cudnn.h
-					HINTS ${CUDA_INCLUDE_DIRS} ENV CUDNN_INCLUDE_DIR  ENV CUDNN_HOME
+		FIND_PATH(cudnn_include cudnn.h
+					HINTS ${CUDA_INCLUDE_DIRS} ENV CUDNN_INCLUDE_DIR ENV CUDNN_HOME
 					PATHS /usr/local /usr/local/cuda ENV CPATH
 					PATH_SUFFIXES include)
 
-		get_filename_component(cudnn_hint_path "${CUDA_CUBLAS_LIBRARIES}" PATH)
-		find_library(cudnn cudnn
+		GET_FILENAME_COMPONENT(cudnn_hint_path "${CUDA_CUBLAS_LIBRARIES}" PATH)
+		FIND_LIBRARY(cudnn cudnn
 					HINTS ${cudnn_hint_path} ENV CUDNN_LIBRARY_DIR  ENV CUDNN_HOME
 					PATHS /usr/local /usr/local/cuda ENV LD_LIBRARY_PATH
 					PATH_SUFFIXES lib64 lib x64)
 		IF (cudnn AND cudnn_include)
-			 message(STATUS "Found cuDNN: " ${cudnn})
+			 MESSAGE(STATUS "Found cuDNN: " ${cudnn})
 			ADD_COMPILE_DEFINITIONS (CUDNN) # TODO this needs to be renamed
 			ADD_COMPILE_DEFINITIONS (CUDNN_HALF)
 			SET (DARKNET_LINK_LIBS ${DARKNET_LINK_LIBS} ${cudnn})
 		ELSE ()
-			MESSAGE (STATUS "Skipping cuDNN")
+			MESSAGE (WARNING "cuDNN not found.")
 		ENDIF ()
 ENDIF ()
+
 
 # ========================
 # == Intel/AMD Hardware ==

--- a/CM_dependencies.cmake
+++ b/CM_dependencies.cmake
@@ -52,41 +52,27 @@ ENDIF ()
 # == cuDNN ==
 # ===========
 IF (DARKNET_USE_CUDA)
-	IF (WIN32)
-		# If installed according to the NVIDIA instructions, CUDNN should look like this:
-		#		C:\Program Files\NVIDIA\CUDNN\v8.x\...
-		# The .dll is named:
-		#		C:\Program Files\NVIDIA\CUDNN\v8.x\bin\cudnn64_8.dll
-		# And the header should look like:
-		#		C:\Program Files\NVIDIA\CUDNN\v8.x\include\cudnn.h
-		#
-		SET (CUDNN_DIR "C:/Program Files/NVIDIA/CUDNN/v8.x")
-		SET (CUDNN_DLL "${CUDNN_DIR}/bin/cudnn64_8.dll")
-		SET (CUDNN_LIB "${CUDNN_DIR}/lib/x64/cudnn.lib")
-		SET (CUDNN_HEADER "${CUDNN_DIR}/include/cudnn.h")
-		IF (EXISTS ${CUDNN_DLL} AND EXISTS ${CUDNN_LIB} AND EXISTS ${CUDNN_HEADER})
-			MESSAGE (STATUS "cuDNN found at ${CUDNN_DIR}")
-			INCLUDE_DIRECTORIES (${CUDNN_DIR}/include/)
-			ADD_COMPILE_DEFINITIONS (CUDNN) # TODO this needs to be renamed
-			ADD_COMPILE_DEFINITIONS (CUDNN_HALF)
-			SET (DARKNET_LINK_LIBS ${DARKNET_LINK_LIBS} ${CUDNN_LIB})
-		ELSE ()
-			MESSAGE (WARNING "Did not find cuDNN at ${CUDNN_DIR}")
-		ENDIF ()
-	ELSE ()
-		# Should be slightly easier to deal with on Linux if it was installed correctly.
-		FIND_LIBRARY (CUDNN cudnn OPTIONAL QUIET)
-		IF (NOT CUDNN)
-			MESSAGE (STATUS "Skipping cuDNN")
-		ELSE ()
-			MESSAGE (STATUS "Enabling cuDNN")
-			ADD_COMPILE_DEFINITIONS (CUDNN) # TODO this needs to be renamed
-			ADD_COMPILE_DEFINITIONS (CUDNN_HALF)
-			SET (DARKNET_LINK_LIBS ${DARKNET_LINK_LIBS} ${CUDNN})
-		ENDIF ()
-	ENDIF ()
-ENDIF ()
+       	# Look for cudnn, we will look in the same place as other CUDA
+		# libraries and also a few other places as well.
+		find_path(cudnn_include cudnn.h
+					HINTS ${CUDA_INCLUDE_DIRS} ENV CUDNN_INCLUDE_DIR  ENV CUDNN_HOME
+					PATHS /usr/local /usr/local/cuda ENV CPATH
+					PATH_SUFFIXES include)
 
+		get_filename_component(cudnn_hint_path "${CUDA_CUBLAS_LIBRARIES}" PATH)
+		find_library(cudnn cudnn
+					HINTS ${cudnn_hint_path} ENV CUDNN_LIBRARY_DIR  ENV CUDNN_HOME
+					PATHS /usr/local /usr/local/cuda ENV LD_LIBRARY_PATH
+					PATH_SUFFIXES lib64 lib x64)
+		IF (cudnn AND cudnn_include)
+			 message(STATUS "Found cuDNN: " ${cudnn})
+			ADD_COMPILE_DEFINITIONS (CUDNN) # TODO this needs to be renamed
+			ADD_COMPILE_DEFINITIONS (CUDNN_HALF)
+			SET (DARKNET_LINK_LIBS ${DARKNET_LINK_LIBS} ${cudnn})
+		ELSE ()
+			MESSAGE (STATUS "Skipping cuDNN")
+		ENDIF ()
+ENDIF ()
 
 # ========================
 # == Intel/AMD Hardware ==


### PR DESCRIPTION
Sorry for the re-create. 
Had to change some things and re set up our for

Hi Stephan,

first of all great work with the last improvements!

This pull request will do 2 things:

Simplify the Cmake code (same for Windows and linux)
Allow for cudnn to be installed in more places (for example in Windows the previous code did not work with all versions since cudnn is often inside the x64 subfolder on windows). This will not only handle this but also take care of the fact that most people install cudnn inside the cuda dir and it also lets you use the CUDNN_HOME env variable if you installed cudnn at any exotic place (or any place u want)

This conforms to the official nvidia install instructions and to what most people do+ allows for custom installs + safes lines + no extra linux/win handling required.