### PR TITLE
Fix sort to comply to  strict weak ordering relation

### DIFF
--- a/src-lib/detector.cpp
+++ b/src-lib/detector.cpp
@@ -1443,7 +1443,7 @@ float validate_detector_map(char *datacfg, char *cfgfile, char *weightfile, floa
 			{
 				const auto diff = lhs.p - rhs.p;
 
-				if (diff < 0.0f)
+				if (diff <= 0.0f)
 				{
 					return false;
 				}


### PR DESCRIPTION
Sort compare needs to compy to weak ordering relation
https://en.cppreference.com/w/cpp/named_req/Compare
especially for an element x, comp(x, x)  has to return false
