### PR TITLE
fix Cudnn Maxpool Stride Order

### DIFF
--- a/src-lib/maxpool_layer.cpp
+++ b/src-lib/maxpool_layer.cpp
@@ -50,8 +50,8 @@ void cudnn_maxpool_setup(layer *l)
 		l->size,
 		l->pad/2, //0, //l.pad,
 		l->pad/2, //0, //l.pad,
-		l->stride_x,
-		l->stride_y));
+		l->stride_y,
+		l->stride_x));
 
 	CHECK_CUDNN(cudnnSetTensor4dDescriptor(l->srcTensorDesc, CUDNN_TENSOR_NCHW, CUDNN_DATA_FLOAT, l->batch, l->c, l->h, l->w));
 	CHECK_CUDNN(cudnnSetTensor4dDescriptor(l->dstTensorDesc, CUDNN_TENSOR_NCHW, CUDNN_DATA_FLOAT, l->batch, l->out_c, l->out_h, l->out_w));
@@ -72,8 +72,8 @@ void cudnn_local_avgpool_setup(layer *l)
 		l->size,
 		l->pad / 2, //0, //l.pad,
 		l->pad / 2, //0, //l.pad,
-		l->stride_x,
-		l->stride_y));
+		l->stride_y,
+		l->stride_x));
 
 	CHECK_CUDNN(cudnnSetTensor4dDescriptor(l->srcTensorDesc, CUDNN_TENSOR_NCHW, CUDNN_DATA_FLOAT, l->batch, l->c, l->h, l->w));
 	CHECK_CUDNN(cudnnSetTensor4dDescriptor(l->dstTensorDesc, CUDNN_TENSOR_NCHW, CUDNN_DATA_FLOAT, l->batch, l->out_c, l->out_h, l->out_w));


### PR DESCRIPTION
Fixes order of maxpool `stride_x` and `stride_y` when calling `cudnnSetPooling2dDescriptor()`. 

Reference: https://docs.nvidia.com/deeplearning/cudnn/archives/cudnn-897/api/index.html#cudnnSetPooling2dDescriptor

Relates to Issue #77 