### PR TITLE
Added a check to ensure the '-map' flag is required when using the 'train' function.

### DIFF
--- a/src-lib/detector.cpp
+++ b/src-lib/detector.cpp
@@ -2323,7 +2323,10 @@ void run_detector(int argc, char **argv)
 	if (not fn4.empty())	{ input_fn	= const_cast<char*>(fn4.c_str()); }
 
 	if		(cfg_and_state.function == "test"		) { test_detector(datacfg, cfg, weights, input_fn, thresh, hier_thresh, dont_show, ext_output, save_labels, outfile, letter_box, benchmark_layers); }
-	else if (cfg_and_state.function == "train"		) { train_detector(datacfg, cfg, weights, gpus, ngpus, clear, dont_show, calc_map, thresh, iou_thresh, show_imgs, benchmark_layers, chart_path); }
+	else if (cfg_and_state.function == "train"		) {
+		if (!calc_map) darknet_fatal_error(DARKNET_LOC, "Error: The '-map' flag is required when using 'train'");
+		train_detector(datacfg, cfg, weights, gpus, ngpus, clear, dont_show, calc_map, thresh, iou_thresh, show_imgs, benchmark_layers, chart_path);
+	}
 	else if (cfg_and_state.function == "valid"		) { validate_detector(datacfg, cfg, weights, outfile); }
 	else if (cfg_and_state.function == "recall"		) { validate_detector_recall(datacfg, cfg, weights); }
 	else if (cfg_and_state.function == "map"		) { validate_detector_map(datacfg, cfg, weights, thresh, iou_thresh, map_points, letter_box, NULL); }


### PR DESCRIPTION
Refactor detector functions for clarity and validation

- Added a check to ensure the '-map' flag is required when using the 'train' function.

Fix #112 

Previous behavior:
![Image](https://github.com/user-attachments/assets/f7d70873-560a-4a7e-b788-6929bbddd805)
After:
![image](https://github.com/user-attachments/assets/47bc8e1e-36e8-4624-9279-5386cc45d25b)

