### PR TITLE
use <version> (introduced in C++20) instead of <ciso646> (deprecated)

### DIFF
--- a/src-lib/darknet.hpp
+++ b/src-lib/darknet.hpp
@@ -14,7 +14,6 @@
  */
 
 #include <atomic>
-#include <ciso646>
 #include <filesystem>
 #include <iostream>
 #include <map>
@@ -24,6 +23,12 @@
 #include <string>
 #include <thread>
 #include <vector>
+
+#if __has_include(<version>)
+#  include <version>
+#else
+#  include <ciso646>
+#endif
 
 #include <opencv2/opencv.hpp>
 

--- a/src-lib/darknet_internal.hpp
+++ b/src-lib/darknet_internal.hpp
@@ -20,7 +20,11 @@
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
-#include <ciso646>
+#if __has_include(<version>)
+#  include <version>
+#else
+#  include <ciso646>
+#endif
 
 // C++ headers
 #include <chrono>


### PR DESCRIPTION
Use <version> (introduced in C++20) instead of <ciso646> (deprecated in C++17).

This fixes GCC15 compiler warnings in darknet, e.g.:

```bash
In file included from /home/trougnouf/aur/darknet-cpu/src/darknet/src-lib/darknet_internal.hpp:23,
                 from /home/trougnouf/aur/darknet-cpu/src/darknet/src-lib/col2im.cpp:2:
/usr/include/c++/15.1.1/ciso646:46:4: warning: #warning "<ciso646> is deprecated in C++17, use <version> to detect implementation-specific macros" [-Wcpp]
   46 | #  warning "<ciso646> is deprecated in C++17, use <version> to detect implementation-specific macros"
      |    ^~~~~~~
```

and also makes it possible to compile DarkHelp which failed due to -Werror