### PR TITLE
Add GPU check before starting Darknet build in google colab

### DIFF
--- a/colab/02_Building_Darknet_and_DarkHelp_to_use_the_Python_interface.ipynb
+++ b/colab/02_Building_Darknet_and_DarkHelp_to_use_the_Python_interface.ipynb
@@ -40,8 +40,11 @@
       },
       "outputs": [],
       "source": [
-        "# make sure the notebook is set to T4 GPU (edit->settings)\n",
-        "!sudo apt-get install build-essential git libopencv-dev cmake\n",
+		"# Check that the google colab instance provides a GPU before starting",
+		"import os\n",
+		"assert os.environ.get("COLAB_GPU"), 'GPU required. Change runtime type to GPU in Edit > Notebook settings > T4 GPU'\n",
+		"\n",
+		"!sudo apt-get install build-essential git libopencv-dev cmake\n",
         "\n",
         "%mkdir -p ~/src\n",
         "%cd ~/src\n",


### PR DESCRIPTION
Just a simple check that might save future users time debugging if they didn't change the instance type already.