### PR TITLE
Fix the breaking macOS github workflow

### DIFF
--- a/.github/workflows/build-darknet.yml
+++ b/.github/workflows/build-darknet.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
-          - os: macos-14
+          - os: macos-15
           - os: windows-2022
 
     steps:


### PR DESCRIPTION
It turned out to be easier than I expected.
Here is the output of the success run: https://github.com/AlexGx/darknet/actions/runs/19478804663/job/55745354294